### PR TITLE
Feat/data provider trait

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2673,6 +2673,7 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 name = "market_data_ingestor"
 version = "1.2.0"
 dependencies = [
+ "async-trait",
  "bincode",
  "chrono",
  "clap",

--- a/src/market_data_ingestor/Cargo.toml
+++ b/src/market_data_ingestor/Cargo.toml
@@ -9,6 +9,7 @@ cli = ["clap"]
 alpaca-python-sdk = ["pyo3"] 
 
 [dependencies]
+async-trait = "0.1.88"
 bincode = "2.0.1"
 chrono = "0.4.39"
 clap = { version = "4.5.30", features = ["derive"], optional = true }

--- a/src/market_data_ingestor/src/cli/params.rs
+++ b/src/market_data_ingestor/src/cli/params.rs
@@ -12,17 +12,15 @@ use crate::models::{
 use super::commands::BatchParamItem;
 
 pub fn parse_timeframe(amount: u32, unit: &str) -> Result<TimeFrame, Box<dyn Error>> {
-    match unit.trim().to_lowercase().as_str() {
+    let unit = match unit.trim().to_lowercase().as_str() {
         "m" | "min" | "minute" => TimeFrame::new(amount, TimeFrameUnit::Minute),
         "h" | "hr" | "hour" => TimeFrame::new(amount, TimeFrameUnit::Hour),
         "d" | "day" => TimeFrame::new(amount, TimeFrameUnit::Day),
         "w" | "wk" | "week" => TimeFrame::new(amount, TimeFrameUnit::Week),
         "M" | "mo" | "month" => TimeFrame::new(amount, TimeFrameUnit::Month),
-        _ => Err(TimeFrameError::InvalidInput {
-            message: format!("Invalid timeframe unit: {}", unit),
-        }),
-    }
-    .map_err(|e| e.into())
+        _ => return Err(TimeFrameError::InvalidInput { message: format!("Invalid timeframe unit: {}", unit)}),
+    };
+    Ok(TimeFrame::new(amount, unit))
 }
 
 #[cfg(feature = "alpaca-python-sdk")]

--- a/src/market_data_ingestor/src/cli/params.rs
+++ b/src/market_data_ingestor/src/cli/params.rs
@@ -18,7 +18,7 @@ pub fn parse_timeframe(amount: u32, unit: &str) -> Result<TimeFrame, Box<dyn Err
         "d" | "day" => TimeFrame::new(amount, TimeFrameUnit::Day),
         "w" | "wk" | "week" => TimeFrame::new(amount, TimeFrameUnit::Week),
         "mo" | "month" => TimeFrame::new(amount, TimeFrameUnit::Month),
-        _ => return Err(TimeFrameError::InvalidInput { message: format!("Invalid timeframe unit: {}", unit)}),
+        _ => return Box::new(TimeFrameError::InvalidInput { message: format!("Invalid timeframe unit: {}", unit)}),
     };
     Ok(TimeFrame::new(amount, unit))
 }

--- a/src/market_data_ingestor/src/cli/params.rs
+++ b/src/market_data_ingestor/src/cli/params.rs
@@ -17,7 +17,7 @@ pub fn parse_timeframe(amount: u32, unit: &str) -> Result<TimeFrame, Box<dyn Err
         "h" | "hr" | "hour" => TimeFrame::new(amount, TimeFrameUnit::Hour),
         "d" | "day" => TimeFrame::new(amount, TimeFrameUnit::Day),
         "w" | "wk" | "week" => TimeFrame::new(amount, TimeFrameUnit::Week),
-        "M" | "mo" | "month" => TimeFrame::new(amount, TimeFrameUnit::Month),
+        "mo" | "month" => TimeFrame::new(amount, TimeFrameUnit::Month),
         _ => return Err(TimeFrameError::InvalidInput { message: format!("Invalid timeframe unit: {}", unit)}),
     };
     Ok(TimeFrame::new(amount, unit))

--- a/src/market_data_ingestor/src/lib.rs
+++ b/src/market_data_ingestor/src/lib.rs
@@ -10,6 +10,7 @@ pub mod cli;
 pub mod errors;
 pub mod io;
 pub mod models;
+pub mod providers;
 pub mod requests;
 pub mod utils;
 

--- a/src/market_data_ingestor/src/models/bar.rs
+++ b/src/market_data_ingestor/src/models/bar.rs
@@ -5,13 +5,11 @@
 
 use chrono::{DateTime, Utc};
 
-/// A single time-series bar (OHLCV) for a given symbol and timestamp.
+/// A single time-series bar (OHLCV) for a given timestamp.
 ///
 /// This struct is vendor-agnostic and is used throughout the data ingestion pipeline.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Bar {
-    /// The symbol this bar represents (e.g., "AAPL", "ESU24", "BTC-USD").
-    pub symbol: String,
 
     /// The timestamp for this bar (UTC).
     pub timestamp: DateTime<Utc>,

--- a/src/market_data_ingestor/src/models/bar.rs
+++ b/src/market_data_ingestor/src/models/bar.rs
@@ -1,0 +1,12 @@
+use chrono::{DateTime, Utc};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Bar {
+    pub symbol: String,
+    pub timestamp: DateTime<Utc>,
+    pub open: f64,
+    pub high: f64,
+    pub low: f64,
+    pub close: f64,
+    pub volume: f64,
+}

--- a/src/market_data_ingestor/src/models/bar.rs
+++ b/src/market_data_ingestor/src/models/bar.rs
@@ -1,12 +1,33 @@
+//! Canonical in-memory representation of a time-series bar (OHLCV).
+//!
+//! This struct is used as the standard output for all [`DataProvider`](crate::providers::DataProvider)
+//! implementations, regardless of asset class (stocks, futures, crypto, etc.).
+
 use chrono::{DateTime, Utc};
 
+/// A single time-series bar (OHLCV) for a given symbol and timestamp.
+///
+/// This struct is vendor-agnostic and is used throughout the data ingestion pipeline.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Bar {
+    /// The symbol this bar represents (e.g., "AAPL", "ESU24", "BTC-USD").
     pub symbol: String,
+
+    /// The timestamp for this bar (UTC).
     pub timestamp: DateTime<Utc>,
+
+    /// Opening price.
     pub open: f64,
+
+    /// Highest price during the bar interval.
     pub high: f64,
+
+    /// Lowest price during the bar interval.
     pub low: f64,
+
+    /// Closing price.
     pub close: f64,
+
+    /// Volume traded during the bar interval.
     pub volume: f64,
 }

--- a/src/market_data_ingestor/src/models/bar_series.rs
+++ b/src/market_data_ingestor/src/models/bar_series.rs
@@ -1,0 +1,17 @@
+//! A collection of time-series bars for a specific symbol and timeframe.
+
+use crate::models::{bar::Bar, timeframe::TimeFrame};
+
+/// Represents a complete set of time-series data for a single symbol.
+///
+/// This struct groups a vector of [`Bar`]s with their corresponding symbol
+/// and [`TimeFrame`], making the data set self-describing.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TimeSeries {
+    /// The symbol this data represents (e.g., "AAPL", "ESU24").
+    pub symbol: String,
+    /// The time interval for each bar in the series.
+    pub timeframe: TimeFrame,
+    /// The collection of OHLCV bars.
+    pub bars: Vec<Bar>,
+}

--- a/src/market_data_ingestor/src/models/bar_series.rs
+++ b/src/market_data_ingestor/src/models/bar_series.rs
@@ -7,7 +7,7 @@ use crate::models::{bar::Bar, timeframe::TimeFrame};
 /// This struct groups a vector of [`Bar`]s with their corresponding symbol
 /// and [`TimeFrame`], making the data set self-describing.
 #[derive(Debug, Clone, PartialEq)]
-pub struct TimeSeries {
+pub struct BarSeries {
     /// The symbol this data represents (e.g., "AAPL", "ESU24").
     pub symbol: String,
     /// The time interval for each bar in the series.

--- a/src/market_data_ingestor/src/models/mod.rs
+++ b/src/market_data_ingestor/src/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod asset;
+pub mod bar;
 pub mod request_params;
 #[cfg(feature = "alpaca-python-sdk")]
 pub mod stockbars;

--- a/src/market_data_ingestor/src/models/mod.rs
+++ b/src/market_data_ingestor/src/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod asset;
 pub mod bar;
+pub mod bar_series;
 pub mod request_params;
 #[cfg(feature = "alpaca-python-sdk")]
 pub mod stockbars;

--- a/src/market_data_ingestor/src/models/timeframe.rs
+++ b/src/market_data_ingestor/src/models/timeframe.rs
@@ -36,36 +36,36 @@ impl TimeFrame {
         Self { amount, unit }
     }
 
-    // fn validate(amount: u32, unit: TimeFrameUnit) -> Result<(), TimeFrameError> {
-    //     match unit {
-    //         TimeFrameUnit::Minute if !(1..=59).contains(&amount) => {
-    //             Err(TimeFrameError::InvalidAmount {
-    //                 unit,
-    //                 message: "Second or Minute units can only be used with amounts between 1-59."
-    //                     .into(),
-    //             })
-    //         }
-    //         TimeFrameUnit::Hour if !(1..=23).contains(&amount) => {
-    //             Err(TimeFrameError::InvalidAmount {
-    //                 unit,
-    //                 message: "Hour units can only be used with amounts 1-23".into(),
-    //             })
-    //         }
-    //         TimeFrameUnit::Day | TimeFrameUnit::Week if amount != 1 => {
-    //             Err(TimeFrameError::InvalidAmount {
-    //                 unit,
-    //                 message: "Day and Week units can only be used with amount 1".into(),
-    //             })
-    //         }
-    //         TimeFrameUnit::Month if ![1, 2, 3, 6, 12].contains(&amount) => {
-    //             Err(TimeFrameError::InvalidAmount {
-    //                 unit,
-    //                 message: "Month units can only be used with amount 1, 2, 3, 6 and 12".into(),
-    //             })
-    //         }
-    //         _ => Ok(()),
-    //     }
-    // }
+    fn _validate(amount: u32, unit: TimeFrameUnit) -> Result<(), TimeFrameError> {
+        match unit {
+            TimeFrameUnit::Minute if !(1..=59).contains(&amount) => {
+                Err(TimeFrameError::InvalidAmount {
+                    unit,
+                    message: "Second or Minute units can only be used with amounts between 1-59."
+                        .into(),
+                })
+            }
+            TimeFrameUnit::Hour if !(1..=23).contains(&amount) => {
+                Err(TimeFrameError::InvalidAmount {
+                    unit,
+                    message: "Hour units can only be used with amounts 1-23".into(),
+                })
+            }
+            TimeFrameUnit::Day | TimeFrameUnit::Week if amount != 1 => {
+                Err(TimeFrameError::InvalidAmount {
+                    unit,
+                    message: "Day and Week units can only be used with amount 1".into(),
+                })
+            }
+            TimeFrameUnit::Month if ![1, 2, 3, 6, 12].contains(&amount) => {
+                Err(TimeFrameError::InvalidAmount {
+                    unit,
+                    message: "Month units can only be used with amount 1, 2, 3, 6 and 12".into(),
+                })
+            }
+            _ => Ok(()),
+        }
+    }
 }
 
 #[cfg(feature = "alpaca-python-sdk")]

--- a/src/market_data_ingestor/src/models/timeframe.rs
+++ b/src/market_data_ingestor/src/models/timeframe.rs
@@ -30,41 +30,42 @@ pub struct TimeFrame {
 }
 
 impl TimeFrame {
-    pub fn new(amount: u32, unit: TimeFrameUnit) -> Result<Self, TimeFrameError> {
-        Self::validate(amount, unit.clone())?;
-        Ok(Self { amount, unit })
+    pub fn new(amount: u32, unit: TimeFrameUnit) -> Self {
+        // Self::validate(amount, unit.clone())?;
+        // Ok(Self { amount, unit })
+        Self { amount, unit }
     }
 
-    fn validate(amount: u32, unit: TimeFrameUnit) -> Result<(), TimeFrameError> {
-        match unit {
-            TimeFrameUnit::Minute if !(1..=59).contains(&amount) => {
-                Err(TimeFrameError::InvalidAmount {
-                    unit,
-                    message: "Second or Minute units can only be used with amounts between 1-59."
-                        .into(),
-                })
-            }
-            TimeFrameUnit::Hour if !(1..=23).contains(&amount) => {
-                Err(TimeFrameError::InvalidAmount {
-                    unit,
-                    message: "Hour units can only be used with amounts 1-23".into(),
-                })
-            }
-            TimeFrameUnit::Day | TimeFrameUnit::Week if amount != 1 => {
-                Err(TimeFrameError::InvalidAmount {
-                    unit,
-                    message: "Day and Week units can only be used with amount 1".into(),
-                })
-            }
-            TimeFrameUnit::Month if ![1, 2, 3, 6, 12].contains(&amount) => {
-                Err(TimeFrameError::InvalidAmount {
-                    unit,
-                    message: "Month units can only be used with amount 1, 2, 3, 6 and 12".into(),
-                })
-            }
-            _ => Ok(()),
-        }
-    }
+    // fn validate(amount: u32, unit: TimeFrameUnit) -> Result<(), TimeFrameError> {
+    //     match unit {
+    //         TimeFrameUnit::Minute if !(1..=59).contains(&amount) => {
+    //             Err(TimeFrameError::InvalidAmount {
+    //                 unit,
+    //                 message: "Second or Minute units can only be used with amounts between 1-59."
+    //                     .into(),
+    //             })
+    //         }
+    //         TimeFrameUnit::Hour if !(1..=23).contains(&amount) => {
+    //             Err(TimeFrameError::InvalidAmount {
+    //                 unit,
+    //                 message: "Hour units can only be used with amounts 1-23".into(),
+    //             })
+    //         }
+    //         TimeFrameUnit::Day | TimeFrameUnit::Week if amount != 1 => {
+    //             Err(TimeFrameError::InvalidAmount {
+    //                 unit,
+    //                 message: "Day and Week units can only be used with amount 1".into(),
+    //             })
+    //         }
+    //         TimeFrameUnit::Month if ![1, 2, 3, 6, 12].contains(&amount) => {
+    //             Err(TimeFrameError::InvalidAmount {
+    //                 unit,
+    //                 message: "Month units can only be used with amount 1, 2, 3, 6 and 12".into(),
+    //             })
+    //         }
+    //         _ => Ok(()),
+    //     }
+    // }
 }
 
 #[cfg(feature = "alpaca-python-sdk")]

--- a/src/market_data_ingestor/src/models/timeframe.rs
+++ b/src/market_data_ingestor/src/models/timeframe.rs
@@ -14,7 +14,7 @@ pub enum TimeFrameError {
     InvalidInput { message: String },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TimeFrameUnit {
     Minute,
     Hour,
@@ -23,7 +23,7 @@ pub enum TimeFrameUnit {
     Month,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TimeFrame {
     pub amount: u32,
     pub unit: TimeFrameUnit,

--- a/src/market_data_ingestor/src/providers/mod.rs
+++ b/src/market_data_ingestor/src/providers/mod.rs
@@ -18,7 +18,7 @@
 //! struct MyProvider;
 //! #[async_trait]
 //! impl DataProvider for MyProvider {
-//!     async fn fetch_bars(&self, params: BarsRequestParams) -> Result<Vec<Bar>, anyhow::Error> {
+//!     async fn fetch_bars(&self, params: BarsRequestParams) -> Result<Vec<BarSeries>, anyhow::Error> {
 //!         // Implementation here...
 //!         Ok(vec![])
 //!     }

--- a/src/market_data_ingestor/src/providers/mod.rs
+++ b/src/market_data_ingestor/src/providers/mod.rs
@@ -12,7 +12,7 @@ mod tests {
     use async_trait::async_trait;
     use chrono::Utc;
 
-    use crate::models::{asset::AssetClass, timeframe::TimeFrame};
+    use crate::models::{asset::AssetClass, timeframe::{TimeFrame, TimeFrameUnit}};
 
     use super::*;
     

--- a/src/market_data_ingestor/src/providers/mod.rs
+++ b/src/market_data_ingestor/src/providers/mod.rs
@@ -1,3 +1,30 @@
+//! Provider abstraction for market data sources.
+//!
+//! This module defines the [`DataProvider`] trait, which serves as a unified interface
+//! for fetching time-series bar data from any market data vendor (e.g., Alpaca, Polygon.io).
+//!
+//! Each concrete provider implementation (such as Alpaca or Polygon) should implement
+//! [`DataProvider`] to handle vendor-specific API logic and validation.
+//!
+//! The trait is designed for async usage and supports dynamic dispatch (`dyn DataProvider`)
+//! for runtime selection of providers.
+//!
+//! # Example
+//!
+//! ```rust
+//! # use market_data_ingestor::models::{bar::Bar, request_params::BarsRequestParams};
+//! # use market_data_ingestor::providers::DataProvider;
+//! # use async_trait::async_trait;
+//! struct MyProvider;
+//! #[async_trait]
+//! impl DataProvider for MyProvider {
+//!     async fn fetch_bars(&self, params: BarsRequestParams) -> Result<Vec<Bar>, anyhow::Error> {
+//!         // Implementation here...
+//!         Ok(vec![])
+//!     }
+//! }
+//! ```
+//! 
 use async_trait::async_trait;
 
 use crate::{errors::IngestorError, models::{bar::Bar, request_params::BarsRequestParams}};

--- a/src/market_data_ingestor/src/providers/mod.rs
+++ b/src/market_data_ingestor/src/providers/mod.rs
@@ -49,7 +49,7 @@ mod tests {
     #[async_trait]
     impl DataProvider for AlpacaProvider {
         async fn fetch_bars(&self, params: BarsRequestParams) -> Result<Vec<BarSeries>, IngestorError> {
-            println!("Fetching from alapca for symbols: {:?}", params.symbols);
+            println!("Fetching from alpaca for symbols: {:?}", params.symbols);
             Ok(vec![])
         }
     }

--- a/src/market_data_ingestor/src/providers/mod.rs
+++ b/src/market_data_ingestor/src/providers/mod.rs
@@ -27,11 +27,11 @@
 //! 
 use async_trait::async_trait;
 
-use crate::{errors::IngestorError, models::{bar::Bar, request_params::BarsRequestParams}};
+use crate::{errors::IngestorError, models::{bar_series::BarSeries, request_params::BarsRequestParams}};
 
 #[async_trait]
 pub trait DataProvider {
-    async fn fetch_bars(&self, params: BarsRequestParams) -> Result<Vec<Bar>, IngestorError>;
+    async fn fetch_bars(&self, params: BarsRequestParams) -> Result<Vec<BarSeries>, IngestorError>;
 }
 
 #[cfg(test)]
@@ -48,7 +48,7 @@ mod tests {
 
     #[async_trait]
     impl DataProvider for AlpacaProvider {
-        async fn fetch_bars(&self, params: BarsRequestParams) -> Result<Vec<Bar>, IngestorError> {
+        async fn fetch_bars(&self, params: BarsRequestParams) -> Result<Vec<BarSeries>, IngestorError> {
             println!("Fetching from alapca for symbols: {:?}", params.symbols);
             Ok(vec![])
         }
@@ -56,7 +56,7 @@ mod tests {
 
     #[async_trait]
     impl DataProvider for PolygonProvider {
-        async fn fetch_bars(&self, params: BarsRequestParams) -> Result<Vec<Bar>, IngestorError> {
+        async fn fetch_bars(&self, params: BarsRequestParams) -> Result<Vec<BarSeries>, IngestorError> {
             println!("Fetching from Polygon.io for symbols: {:?}", params.symbols);
             Ok(vec![]) // Return dummy data
         }


### PR DESCRIPTION
close #13 

This pull request introduces significant enhancements to the `market_data_ingestor` module, focusing on adding new abstractions, improving data models, and simplifying error handling. Key changes include the introduction of a `DataProvider` trait for unified market data fetching, new structs for time-series data representation, and streamlined validation logic for timeframes.

### Enhancements to Market Data Abstraction:
* **Introduced `DataProvider` trait**: Added a unified interface for fetching time-series bar data from various market data vendors, supporting async usage and dynamic dispatch. Includes example implementations and runtime selection logic. (`src/market_data_ingestor/src/providers/mod.rs`)

### Improvements to Data Models:
* **Added `Bar` struct**: Defined a canonical representation for OHLCV (Open, High, Low, Close, Volume) data, vendor-agnostic and used across the data ingestion pipeline. (`src/market_data_ingestor/src/models/bar.rs`)
* **Added `BarSeries` struct**: Created a self-describing collection of `Bar` objects, grouped by symbol and timeframe. (`src/market_data_ingestor/src/models/bar_series.rs`)
* **Updated `TimeFrame` and `TimeFrameUnit`**: Enhanced these structs with additional traits (`PartialEq`, `Eq`, `PartialOrd`, `Ord`) and removed validation logic for simplicity. (`src/market_data_ingestor/src/models/timeframe.rs`) [[1]](diffhunk://#diff-08ced04cfbb2cbb7ba84604d3305e3421c50128b58aa332630b3aa798a3e7128L17-R17) [[2]](diffhunk://#diff-08ced04cfbb2cbb7ba84604d3305e3421c50128b58aa332630b3aa798a3e7128L26-R68)

### Code Organization:
* **Expanded `models` module**: Added `bar` and `bar_series` submodules to organize new data structures. (`src/market_data_ingestor/src/models/mod.rs`)
* **Added `providers` module**: Introduced a dedicated module for market data provider abstractions. (`src/market_data_ingestor/src/lib.rs`)

### Dependency Updates:
* **Added `async-trait` dependency**: Enabled asynchronous trait definitions for the `DataProvider` interface. (`src/market_data_ingestor/Cargo.toml`)